### PR TITLE
#152 fix: prevent cross-record merge hybrids in diff parsing

### DIFF
--- a/src/wslcb_licensing_tracker/parser.py
+++ b/src/wslcb_licensing_tracker/parser.py
@@ -81,6 +81,61 @@ def normalize_date(date_str: str) -> str:
 
 _CELL_COUNT = 2
 
+# Maps each record-field label to the primary dict key it populates. A single
+# WSLCB block sets each of these at most once, so re-setting an already-populated
+# field to a *different* value means a new block has begun. This detects record
+# boundaries in diff-derived streams where a block's date/name (and sometimes
+# license-number) rows were unchanged context — and thus stripped from the
+# changed-only line stream. Without it, the second block's fields overwrite the
+# first block's accumulator, producing a hybrid record (one entity's name/date
+# glued onto another license's number/type/location). See tests/test_parser.py
+# ::TestDiffMergeBoundary and real record 31982.
+#
+# The New/Current pairs deliberately map to *different* keys (business_name vs
+# previous_business_name, etc.) so ASSUMPTION and CHANGE OF LOCATION records —
+# which legitimately carry both — never trip the boundary check.
+_PRIMARY_FIELD = {
+    "Business Name:": "business_name",
+    "New Business Name:": "business_name",
+    "Current Business Name:": "previous_business_name",
+    "Business Location:": "business_location",
+    "New Business Location:": "business_location",
+    "Current Business Location:": "previous_business_location",
+    "Applicant(s):": "applicants",
+    "New Applicant(s):": "applicants",
+    "Current Applicant(s):": "previous_applicants",
+    "License Type:": "license_type",
+    "Application Type:": "application_type",
+    "\\Application Type:": "application_type",
+    "License Number:": "license_number",
+    "Contact Phone:": "contact_phone",
+}
+
+
+def _empty_record(section_type: str, scraped_at: datetime, record_date: str = "") -> dict:
+    """Return a fresh record dict with all fields zeroed."""
+    return {
+        "section_type": section_type,
+        "record_date": record_date,
+        "business_name": "",
+        "business_location": "",
+        "applicants": "",
+        "license_type": "",
+        "application_type": "",
+        "license_number": "",
+        "contact_phone": "",
+        "city": "",
+        "state": "WA",
+        "zip_code": "",
+        "previous_business_name": "",
+        "previous_applicants": "",
+        "previous_business_location": "",
+        "previous_city": "",
+        "previous_state": "",
+        "previous_zip_code": "",
+        "scraped_at": scraped_at,
+    }
+
 
 def parse_records_from_table(  # noqa: C901, PLR0912, PLR0915  # WSLCB field dispatch; not worth splitting
     table: "BeautifulSoup",
@@ -89,9 +144,9 @@ def parse_records_from_table(  # noqa: C901, PLR0912, PLR0915  # WSLCB field dis
     """Parse all records from a section table."""
     records = []
     rows = table.find_all("tr")
-    current = {}
     date_field = DATE_FIELD_MAP[section_type]
     scraped_at = datetime.now(UTC)
+    current = _empty_record(section_type, scraped_at)
 
     for row in rows:
         cells = row.find_all("td")
@@ -106,28 +161,21 @@ def parse_records_from_table(  # noqa: C901, PLR0912, PLR0915  # WSLCB field dis
             # Start of a new record — save previous if complete
             if current.get("license_number"):
                 records.append(current)
-            current = {
-                "section_type": section_type,
-                "record_date": normalize_date(value),
-                "business_name": "",
-                "business_location": "",
-                "applicants": "",
-                "license_type": "",
-                "application_type": "",
-                "license_number": "",
-                "contact_phone": "",
-                "city": "",
-                "state": "WA",
-                "zip_code": "",
-                "previous_business_name": "",
-                "previous_applicants": "",
-                "previous_business_location": "",
-                "previous_city": "",
-                "previous_state": "",
-                "previous_zip_code": "",
-                "scraped_at": scraped_at,
-            }
-        elif label == "Business Name:":
+            current = _empty_record(section_type, scraped_at, normalize_date(value))
+            continue
+
+        # Implicit boundary: re-setting an already-populated field to a different
+        # value means a new block began without its date row (dropped diff
+        # context). Flush the completed block (if it reached a license number)
+        # and restart so the two blocks don't merge into a hybrid. Incomplete
+        # fragments are recovered by the supplemental with-context pass.
+        prim = _PRIMARY_FIELD.get(label)
+        if prim and current.get(prim) and current[prim] != value:
+            if current.get("license_number"):
+                records.append(current)
+            current = _empty_record(section_type, scraped_at)
+
+        if label == "Business Name:":
             current["business_name"] = value
         elif label == "New Business Name:":
             # ASSUMPTION records: buyer's business name

--- a/src/wslcb_licensing_tracker/parser.py
+++ b/src/wslcb_licensing_tracker/parser.py
@@ -168,7 +168,9 @@ def parse_records_from_table(  # noqa: C901, PLR0912, PLR0915  # WSLCB field dis
         # value means a new block began without its date row (dropped diff
         # context). Flush the completed block (if it reached a license number)
         # and restart so the two blocks don't merge into a hybrid. Incomplete
-        # fragments are recovered by the supplemental with-context pass.
+        # fragments are recovered by the supplemental with-context pass. The
+        # comparison is exact-string: WSLCB emits each field once per block with
+        # a stable value, so this never fires spuriously within one real block.
         prim = _PRIMARY_FIELD.get(label)
         if prim and current.get(prim) and current[prim] != value:
             if current.get("license_number"):
@@ -423,6 +425,13 @@ def extract_records_from_diff(filepath: Path, section_type: str) -> list[dict]:
     docstring.  The supplemental (with-context) pass is only run when the
     primary pass produced incomplete records at hunk boundaries, keeping
     overall parse time low.
+
+    ``parse_records_from_table`` also emits boundary-split fragments: when a
+    later block's date/name rows were unchanged context (absent from the
+    changed-only stream), its remaining fields are detected as a new block via
+    field-overwrite rather than being merged into the preceding record. The
+    dateless fragment is invalid on the primary pass and recovered here by the
+    supplemental pass. See ``parse_records_from_table`` for the mechanism.
 
     Transparently falls back to a ``.txt.gz`` sibling when *filepath* itself
     doesn't exist, mirroring ``_read_snapshot``'s compression tolerance.

--- a/tests/fixtures/diff_merge_hybrid.txt
+++ b/tests/fixtures/diff_merge_hybrid.txt
@@ -1,0 +1,66 @@
+--- @	Sun, 14 Jun 2025 00:05:06 -0700
++++ @	Mon, 15 Jun 2025 00:15:05 -0700
+@@ -100,10 +100,80 @@
+ <tr style="background: White"><td> </td><td> </td></tr>
++                   <tbody width="100%" style="Font-size: .80em; background: lightgrey">
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F" width="25%"><b>Approved Date:</b></td>
++<td>6/15/2025</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>Business Name:</b></td>
++<td>AAA PRODUCERS LLC</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>Business Location:</b></td>
++<td>111 FIRST ST,  SEATTLE, WA 98101</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>License Type:</b></td>
++<td>391, CANNABIS PRODUCER TIER 2</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>Application Type:</b></td>
++<td>ADDED FEES</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>License Number:</b></td>
++<td>111111</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>Contact Phone:</b></td>
++<td>2065550111</td>
++                      </tr>
++                      <tr style="background: White"><td> </td><td> </td></tr>
++                   </tbody>
+                    <tbody width="100%" style="Font-size: .80em; background: lightgrey">
+                       <tr>
+                          <td align="Right" style="background: #8FBC8F" width="25%"><b>Approved Date:</b></td>
+ <td>6/14/2025</td>
+                       </tr>
+                       <tr>
+                          <td align="Right" style="background: #8FBC8F"><b>Business Name:</b></td>
+ <td>BBB RETAIL INC</td>
+                       </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>Business Location:</b></td>
++<td>222 SECOND AVE,  BELLINGHAM, WA 98226</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>License Type:</b></td>
++<td>394, CANNABIS RETAILER</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>Application Type:</b></td>
++<td>ADDED/CHANGE OF CLASS/IN LIEU</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>License Number:</b></td>
++<td>222222</td>
++                      </tr>
++                      <tr>
++                         <td align="Right" style="background: #8FBC8F"><b>Contact Phone:</b></td>
++<td>2065550222</td>
++                      </tr>
++                      <tr style="background: White"><td> </td><td> </td></tr>
+                    </tbody>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -644,6 +644,86 @@ class TestParseDiffTimestamp:
 # ── extract_records_from_diff (.gz support) ──────────────────────────
 
 
+class TestDiffMergeBoundary:
+    """Regression tests for the cross-record merge bug (#150 follow-up).
+
+    When a diff's changed-lines-only stream omits a later block's
+    ``Approved Date:`` / ``Business Name:`` rows (because they were unchanged
+    context), that block's remaining changed fields must NOT be merged into the
+    preceding record's accumulator. Doing so produced hybrid records: one
+    entity's name/date glued onto another license's number/type/location
+    (e.g. real record 31982 — 'TTL HOLDINGS LLC' stamped on the '2020 CANNABIS
+    SOLUTIONS' retailer license 355469).
+    """
+
+    def _records(self):
+        src = FIXTURES_DIR / "diff_merge_hybrid.txt"
+        return extract_records_from_diff(src, "approved")
+
+    def _by_license(self, recs, lic):
+        return next((r for r in recs if r["license_number"] == lic), None)
+
+    def test_no_hybrid_record(self):
+        """No record pairs block A's business name with block B's license."""
+        recs = self._records()
+        hybrids = [
+            r
+            for r in recs
+            if r["license_number"] == "222222" and r["business_name"] == "AAA PRODUCERS LLC"
+        ]
+        assert hybrids == [], f"hybrid record leaked: {hybrids}"
+
+    def test_block_a_intact(self):
+        """Block A keeps its own license and fields."""
+        a = self._by_license(self._records(), "111111")
+        assert a is not None
+        assert a["business_name"] == "AAA PRODUCERS LLC"
+        assert a["record_date"] == "2025-06-15"
+        assert a["license_type"] == "391, CANNABIS PRODUCER TIER 2"
+
+    def test_block_b_recovered_correctly(self):
+        """Block B is recovered via the context pass with its own name."""
+        b = self._by_license(self._records(), "222222")
+        assert b is not None
+        assert b["business_name"] == "BBB RETAIL INC"
+        assert b["record_date"] == "2025-06-14"
+
+    def test_no_merge_when_block_a_license_is_context(self):
+        """Boundary is detected even when block A's own License Number row was
+        unchanged context (dropped from the changed-only stream), so the trigger
+        can't rely on license_number being set. An overwritten field (here the
+        business location) marks the new block."""
+        # Simulates the added-line stream: block A has no License Number row
+        # (it was context), block B follows with only its later fields present.
+        rows = [
+            ("Approved Date:", "6/15/2025"),
+            ("Business Name:", "AAA PRODUCERS LLC"),
+            ("Business Location:", "111 FIRST ST,  SEATTLE, WA 98101"),
+            ("License Type:", "391, CANNABIS PRODUCER TIER 2"),
+            ("Application Type:", "ADDED FEES"),
+            ("Contact Phone:", "2065550111"),
+            # block B (date/name were context, dropped):
+            ("Business Location:", "222 SECOND AVE,  BELLINGHAM, WA 98226"),
+            ("License Type:", "394, CANNABIS RETAILER"),
+            ("Application Type:", "ADDED/CHANGE OF CLASS/IN LIEU"),
+            ("License Number:", "222222"),
+            ("Contact Phone:", "2065550222"),
+        ]
+        html = (
+            "<table>"
+            + "".join(f"<tr><td>{label}</td><td>{value}</td></tr>" for label, value in rows)
+            + "</table>"
+        )
+        table = BeautifulSoup(html, "lxml").find("table")
+        recs = parse_records_from_table(table, "approved")
+        # No record may pair block A's name with block B's license.
+        assert not [
+            r
+            for r in recs
+            if r["business_name"] == "AAA PRODUCERS LLC" and r["license_number"] == "222222"
+        ]
+
+
 class TestExtractRecordsFromDiffGz:
     def test_reads_gz_directly(self, tmp_path):
         """extract_records_from_diff reads a .txt.gz file when given its path."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -663,6 +663,17 @@ class TestDiffMergeBoundary:
     def _by_license(self, recs, lic):
         return next((r for r in recs if r["license_number"] == lic), None)
 
+    @staticmethod
+    def _table_from_rows(rows):
+        """Build a <table> of two-cell <tr> label/value rows, as the diff parser
+        sees a changed-only line stream (see parse_html_lines)."""
+        html = (
+            "<table>"
+            + "".join(f"<tr><td>{label}</td><td>{value}</td></tr>" for label, value in rows)
+            + "</table>"
+        )
+        return BeautifulSoup(html, "lxml").find("table")
+
     def test_no_hybrid_record(self):
         """No record pairs block A's business name with block B's license."""
         recs = self._records()
@@ -709,13 +720,7 @@ class TestDiffMergeBoundary:
             ("License Number:", "222222"),
             ("Contact Phone:", "2065550222"),
         ]
-        html = (
-            "<table>"
-            + "".join(f"<tr><td>{label}</td><td>{value}</td></tr>" for label, value in rows)
-            + "</table>"
-        )
-        table = BeautifulSoup(html, "lxml").find("table")
-        recs = parse_records_from_table(table, "approved")
+        recs = parse_records_from_table(self._table_from_rows(rows), "approved")
         # No record may pair block A's name with block B's license.
         assert not [
             r
@@ -743,14 +748,9 @@ class TestDiffMergeBoundary:
             ("Application Type:", "ADDED/CHANGE OF CLASS/IN LIEU"),
             ("Contact Phone:", "2065550222"),
         ]
-        html = (
-            "<table>"
-            + "".join(f"<tr><td>{label}</td><td>{value}</td></tr>" for label, value in rows)
-            + "</table>"
-        )
-        table = BeautifulSoup(html, "lxml").find("table")
-        recs = parse_records_from_table(table, "approved")
-        a = next(r for r in recs if r["license_number"] == "111111")
+        recs = parse_records_from_table(self._table_from_rows(rows), "approved")
+        a = self._by_license(recs, "111111")
+        assert a is not None
         assert a["business_location"] == "111 FIRST ST,  SEATTLE, WA 98101"
         assert a["license_type"] == "391, CANNABIS PRODUCER TIER 2"
         assert a["city"] == "SEATTLE"
@@ -776,13 +776,7 @@ class TestDiffMergeBoundary:
             ("License Number:", "078123"),
             ("Contact Phone:", "2065550178"),
         ]
-        html = (
-            "<table>"
-            + "".join(f"<tr><td>{label}</td><td>{value}</td></tr>" for label, value in rows)
-            + "</table>"
-        )
-        table = BeautifulSoup(html, "lxml").find("table")
-        recs = parse_records_from_table(table, "new_application")
+        recs = parse_records_from_table(self._table_from_rows(rows), "new_application")
         assert len(recs) == 1
         r = recs[0]
         assert r["business_name"] == "NEW LEAF DISPENSARY"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -723,6 +723,74 @@ class TestDiffMergeBoundary:
             if r["business_name"] == "AAA PRODUCERS LLC" and r["license_number"] == "222222"
         ]
 
+    def test_class_b_location_and_type_not_borrowed(self):
+        """Class-B case: block B's differing location/type must NOT overwrite
+        block A when block B carries no second License Number (its own date,
+        name and license rows were unchanged context). Block A must keep its own
+        location and type; nothing may pair block A's license with block B's
+        location/type."""
+        rows = [
+            ("Approved Date:", "6/15/2025"),
+            ("Business Name:", "AAA PRODUCERS LLC"),
+            ("Business Location:", "111 FIRST ST,  SEATTLE, WA 98101"),
+            ("License Type:", "391, CANNABIS PRODUCER TIER 2"),
+            ("Application Type:", "ADDED FEES"),
+            ("License Number:", "111111"),
+            ("Contact Phone:", "2065550111"),
+            # block B: only its later fields present (date/name/license context):
+            ("Business Location:", "222 SECOND AVE,  BELLINGHAM, WA 98226"),
+            ("License Type:", "394, CANNABIS RETAILER"),
+            ("Application Type:", "ADDED/CHANGE OF CLASS/IN LIEU"),
+            ("Contact Phone:", "2065550222"),
+        ]
+        html = (
+            "<table>"
+            + "".join(f"<tr><td>{label}</td><td>{value}</td></tr>" for label, value in rows)
+            + "</table>"
+        )
+        table = BeautifulSoup(html, "lxml").find("table")
+        recs = parse_records_from_table(table, "approved")
+        a = next(r for r in recs if r["license_number"] == "111111")
+        assert a["business_location"] == "111 FIRST ST,  SEATTLE, WA 98101"
+        assert a["license_type"] == "391, CANNABIS PRODUCER TIER 2"
+        assert a["city"] == "SEATTLE"
+        assert not [
+            r
+            for r in recs
+            if r["license_number"] == "111111" and r["license_type"] == "394, CANNABIS RETAILER"
+        ]
+
+    def test_new_current_pairs_do_not_split_a_single_block(self):
+        """The New/Current field pairs map to distinct keys, so an ASSUMPTION
+        block (which legitimately carries both) is parsed as ONE record even
+        though the same logical position appears twice — the overwrite boundary
+        check must not fire on them."""
+        rows = [
+            ("Notification Date:", "6/15/2025"),
+            ("New Business Name:", "NEW LEAF DISPENSARY"),
+            ("Current Business Name:", "OLD SMOKE SHOP"),
+            ("New Applicant(s):", "NEW LEAF DISPENSARY; CAROL NEWBY"),
+            ("Current Applicant(s):", "OLD SMOKE SHOP; ALICE OLDEN"),
+            ("License Type:", "CANNABIS RETAILER"),
+            ("Application Type:", "ASSUMPTION"),
+            ("License Number:", "078123"),
+            ("Contact Phone:", "2065550178"),
+        ]
+        html = (
+            "<table>"
+            + "".join(f"<tr><td>{label}</td><td>{value}</td></tr>" for label, value in rows)
+            + "</table>"
+        )
+        table = BeautifulSoup(html, "lxml").find("table")
+        recs = parse_records_from_table(table, "new_application")
+        assert len(recs) == 1
+        r = recs[0]
+        assert r["business_name"] == "NEW LEAF DISPENSARY"
+        assert r["previous_business_name"] == "OLD SMOKE SHOP"
+        assert r["applicants"] == "NEW LEAF DISPENSARY; CAROL NEWBY"
+        assert r["previous_applicants"] == "OLD SMOKE SHOP; ALICE OLDEN"
+        assert r["license_number"] == "078123"
+
 
 class TestExtractRecordsFromDiffGz:
     def test_reads_gz_directly(self, tmp_path):


### PR DESCRIPTION
## What & why

`parse_records_from_table` used the date row as its only record boundary. Fed a diff's changed-lines-only stream, a later block whose date/name rows were unchanged context merged into the preceding record's accumulator — producing hybrid records that glue one entity's name/date onto another license's number/type/location (e.g. record 31982: `TTL HOLDINGS LLC` stamped on the `2020 CANNABIS SOLUTIONS` retailer license 355469).

## Fix

Detect the implicit boundary by **field-overwrite**: a single WSLCB block sets each body field at most once, so re-setting an already-populated field to a different value means a new block began. Flush the completed block and restart; the incomplete fragment is recovered by the existing supplemental with-context pass. Overwrite detection (rather than gating on `license_number`) also handles blocks whose own License Number row was unchanged context. The New/Current field pairs map to distinct keys so ASSUMPTION / CHANGE OF LOCATION records never trip the check.

## Impact & validation

- Corpus scan of 4,429 diff archives: eliminates ~98% of the class (346 confirmed wrong-entity records → a small residual).
- New regression tests in `TestDiffMergeBoundary`: cross-record merge, Class-B (location/type), block-A-license-as-context, and New/Current-pairs-don't-split. **590 tests pass.**

## Scope

Parser + tests only. Data remediation and the residual/structural-limitation follow-ups are tracked in #152 (summary) and #151 (structural redesign). A rare no-field-collision residual remains (documented in #151) and is not addressed here.

Tracking: #152 · Structural follow-up: #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
